### PR TITLE
fix: 兼容少数 LRC 使用冒号作为毫秒分隔符的时间戳格式（30373825)

### DIFF
--- a/clound-music/src/main/kotlin/io/github/proify/lyricon/cmprovider/xposed/parser/LyricParser.kt
+++ b/clound-music/src/main/kotlin/io/github/proify/lyricon/cmprovider/xposed/parser/LyricParser.kt
@@ -23,7 +23,7 @@ object LyricParser {
 
     private val jsonParser = Json { ignoreUnknownKeys = true }
 
-    private val LRC_TIME_REGEX = Pattern.compile("\\[(\\d{1,2}):(\\d{1,2})(\\.(\\d{1,3}))?]")
+    private val LRC_TIME_REGEX = Pattern.compile("\\[(\\d{1,2}):(\\d{1,2})([.:](\\d{1,3}))?]")
     private val YRC_LINE_HEADER_REGEX = Pattern.compile("\\[(\\d+),(\\d+)]")
     private val YRC_SYLLABLE_REGEX = Pattern.compile("\\((\\d+),(\\d+),\\d+\\)([^(]*)")
 


### PR DESCRIPTION
有一些歌曲的lrc不太标准，正则匹配不到，比如 https://y.music.163.com/m/song?id=30373825 ，兼容一下