### PR TITLE
fix(qq-music): 修复跨进程SharedPreferences导致翻译歌词不显示的问题

### DIFF
--- a/qq-music/src/main/kotlin/io/github/proify/lyricon/qmprovider/xposed/MetadataCache.kt
+++ b/qq-music/src/main/kotlin/io/github/proify/lyricon/qmprovider/xposed/MetadataCache.kt
@@ -13,8 +13,8 @@ object MediaMetadataCache {
     private val map = mutableMapOf<String, Metadata>()
 
     fun save(metadata: MediaMetadata): Metadata? {
-        val id = metadata.getString(MediaMetadata.METADATA_KEY_MEDIA_ID)
-        if (id.isNullOrBlank()) return null
+        val id = metadata.getString(MediaMetadata.METADATA_KEY_MEDIA_ID) ?: return null
+        if (id.isBlank()) return null
         if (map.containsKey(id)) {
             return map[id]
         }

--- a/qq-music/src/main/kotlin/io/github/proify/lyricon/qmprovider/xposed/QQMusic.kt
+++ b/qq-music/src/main/kotlin/io/github/proify/lyricon/qmprovider/xposed/QQMusic.kt
@@ -34,6 +34,10 @@ object QQMusic : YukiBaseHooker() {
 
     private const val ACTION_LYRIC_SETTINGS_CHANGED =
         "io.github.proify.lyricon.ACTION_SETTINGS_CHANGED"
+    private const val ACTION_PLAYER_READY =
+        "io.github.proify.lyricon.ACTION_PLAYER_READY"
+    private const val ACTION_SETTINGS_SNAPSHOT =
+        "io.github.proify.lyricon.ACTION_SETTINGS_SNAPSHOT"
     private const val PREF_NAME_QQMUSIC = "qqmusicplayer"
     private const val KEY_DISPLAY_TRANS = "showtranslyric"
     private const val KEY_DISPLAY_ROMA = "showromalyric"
@@ -51,6 +55,9 @@ object QQMusic : YukiBaseHooker() {
 
     /**
      * 处理主进程逻辑：监听 QQ 音乐内部设置变更并广播
+     *
+     * 同时监听来自 PlayerService 的就绪握手广播，将当前设置值主动推送过去，
+     * 解决 PlayerService 重启后无法通过跨进程 SharedPreferences 读取初始值的问题。
      */
     private class MainProcessHook {
         fun hook(loader: ClassLoader) {
@@ -77,6 +84,39 @@ object QQMusic : YukiBaseHooker() {
                         }
                     }
                 }
+
+            onAppLifecycle {
+                onCreate {
+                    registerPlayerReadyReceiver(this)
+                }
+            }
+        }
+
+        /**
+         * 监听 PlayerService 就绪握手。
+         * PlayerService 启动完成后会发送 ACTION_PLAYER_READY，主进程收到后
+         * 立即把当前 SharedPreferences 里的真实值以 ACTION_SETTINGS_SNAPSHOT
+         * 广播回 PlayerService，彻底替代跨进程直读 prefs 的方案。
+         */
+        private fun registerPlayerReadyReceiver(application: Application) {
+            val filter = IntentFilter(ACTION_PLAYER_READY)
+            ContextCompat.registerReceiver(application, object : BroadcastReceiver() {
+                override fun onReceive(context: Context?, intent: Intent?) {
+                    val ctx = context ?: return
+                    // 主进程在自己进程里读取——这里是可靠的
+                    val prefs = ctx.getSharedPreferences(PREF_NAME_QQMUSIC, Context.MODE_PRIVATE)
+                    val trans = prefs.getBoolean(KEY_DISPLAY_TRANS, false)
+                    val roma  = prefs.getBoolean(KEY_DISPLAY_ROMA, false)
+
+                    val snapshot = Intent(ACTION_SETTINGS_SNAPSHOT).apply {
+                        putExtra(KEY_DISPLAY_TRANS, trans)
+                        putExtra(KEY_DISPLAY_ROMA, roma)
+                        setPackage(ctx.packageName)
+                    }
+                    ctx.sendBroadcast(snapshot)
+                    Log.d(TAG, "Player ready, pushed settings snapshot: trans=$trans roma=$roma")
+                }
+            }, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
         }
     }
 
@@ -92,6 +132,8 @@ object QQMusic : YukiBaseHooker() {
                     DiskSongCache.initialize(this)
                     setupLyriconProvider(this)
                     registerSettingsReceiver(this)
+                    // 所有接收器注册完毕后，通知主进程推送当前设置快照
+                    sendReadyBroadcast(this)
                 }
             }
 
@@ -128,19 +170,45 @@ object QQMusic : YukiBaseHooker() {
         }
 
         private fun registerSettingsReceiver(application: Application) {
-            val filter = IntentFilter(ACTION_LYRIC_SETTINGS_CHANGED)
+            val filter = IntentFilter().apply {
+                addAction(ACTION_LYRIC_SETTINGS_CHANGED)
+                addAction(ACTION_SETTINGS_SNAPSHOT)
+            }
 
             ContextCompat.registerReceiver(application, object : BroadcastReceiver() {
                 override fun onReceive(context: Context?, intent: Intent?) {
-                    val key = intent?.getStringExtra("setting_key") ?: return
-                    val value = intent.getBooleanExtra("setting_value", false)
-
-                    when (key) {
-                        KEY_DISPLAY_TRANS -> lyriconProvider?.player?.setDisplayTranslation(value)
-                        KEY_DISPLAY_ROMA -> lyriconProvider?.player?.setDisplayRoma(value)
+                    when (intent?.action) {
+                        ACTION_LYRIC_SETTINGS_CHANGED -> {
+                            val key = intent.getStringExtra("setting_key") ?: return
+                            val value = intent.getBooleanExtra("setting_value", false)
+                            applySettingChange(key, value)
+                        }
+                        ACTION_SETTINGS_SNAPSHOT -> {
+                            // 主进程在收到握手后推来的完整初始快照
+                            val trans = intent.getBooleanExtra(KEY_DISPLAY_TRANS, false)
+                            val roma  = intent.getBooleanExtra(KEY_DISPLAY_ROMA, false)
+                            Log.d(TAG, "Received settings snapshot: trans=$trans roma=$roma")
+                            lyriconProvider?.player?.setDisplayTranslation(trans)
+                            lyriconProvider?.player?.setDisplayRoma(roma)
+                        }
                     }
                 }
             }, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        }
+
+        private fun applySettingChange(key: String, value: Boolean) {
+            when (key) {
+                KEY_DISPLAY_TRANS -> lyriconProvider?.player?.setDisplayTranslation(value)
+                KEY_DISPLAY_ROMA  -> lyriconProvider?.player?.setDisplayRoma(value)
+            }
+        }
+
+        private fun sendReadyBroadcast(application: Application) {
+            val intent = Intent(ACTION_PLAYER_READY).apply {
+                setPackage(application.packageName)
+            }
+            application.sendBroadcast(intent)
+            Log.d(TAG, "Player ready broadcast sent")
         }
 
         private fun setupLyriconProvider(application: Application) {
@@ -151,12 +219,11 @@ object QQMusic : YukiBaseHooker() {
                 logo = ProviderLogo.fromSvg(Constants.ICON)
             )
 
-            // 初始化显示设置
-            val prefs = application.getSharedPreferences(PREF_NAME_QQMUSIC, Context.MODE_PRIVATE)
-            provider.player.apply {
-                setDisplayTranslation(prefs.getBoolean(KEY_DISPLAY_TRANS, false))
-                setDisplayRoma(prefs.getBoolean(KEY_DISPLAY_ROMA, false))
-            }
+            // 不在此处读取 SharedPreferences。
+            // PlayerService 进程无法可靠地跨进程读取主进程写入的 "qqmusicplayer" prefs
+            // （Android 7+ 禁止 MODE_WORLD_READABLE，跨进程读只会得到空文件的默认值）。
+            // 真实初始值由握手机制获取：setupLyriconProvider 完成后 sendReadyBroadcast()
+            // 通知主进程，主进程在自己进程内读取 prefs 后通过 ACTION_SETTINGS_SNAPSHOT 推回来。
 
             provider.register()
             this.lyriconProvider = provider

--- a/qq-music/src/main/kotlin/io/github/proify/lyricon/qmprovider/xposed/QQMusic.kt
+++ b/qq-music/src/main/kotlin/io/github/proify/lyricon/qmprovider/xposed/QQMusic.kt
@@ -88,6 +88,9 @@ object QQMusic : YukiBaseHooker() {
             onAppLifecycle {
                 onCreate {
                     registerPlayerReadyReceiver(this)
+                    // 主进程启动时也主动推送一次快照
+                    // 处理主进程被系统杀死重启、而 PlayerService 仍在运行的边缘情况
+                    sendSettingsSnapshot(this)
                 }
             }
         }
@@ -98,6 +101,20 @@ object QQMusic : YukiBaseHooker() {
          * 立即把当前 SharedPreferences 里的真实值以 ACTION_SETTINGS_SNAPSHOT
          * 广播回 PlayerService，彻底替代跨进程直读 prefs 的方案。
          */
+        private fun sendSettingsSnapshot(application: Application) {
+            val prefs = application.getSharedPreferences(PREF_NAME_QQMUSIC, Context.MODE_PRIVATE)
+            val trans = prefs.getBoolean(KEY_DISPLAY_TRANS, false)
+            val roma  = prefs.getBoolean(KEY_DISPLAY_ROMA, false)
+
+            val snapshot = Intent(ACTION_SETTINGS_SNAPSHOT).apply {
+                putExtra(KEY_DISPLAY_TRANS, trans)
+                putExtra(KEY_DISPLAY_ROMA, roma)
+                setPackage(application.packageName)
+            }
+            application.sendBroadcast(snapshot)
+            Log.d(TAG, "Host process started, pushed settings snapshot: trans=$trans roma=$roma")
+        }
+
         private fun registerPlayerReadyReceiver(application: Application) {
             val filter = IntentFilter(ACTION_PLAYER_READY)
             ContextCompat.registerReceiver(application, object : BroadcastReceiver() {


### PR DESCRIPTION
**问题描述**：QQ 音乐的翻译歌词功能始终不显示，无论是否在设置中开启翻译。

**原因分析**：`setupLyriconProvider()` 在 `QQPlayerService` 进程中通过 `getSharedPreferences("qqmusicplayer", MODE_PRIVATE)` 读取翻译开关的初始值。但 `qqmusicplayer` 是由主进程写入的，Android 7+ 禁止跨进程读取 `MODE_PRIVATE` 的 SharedPreferences，子进程读到的是自己沙箱里的空文件，`getBoolean` 必然返回默认值 `false`，导致翻译在启动时就被关闭。

此外广播机制只在用户手动切换开关时触发，若用户在 PlayerService 启动之前已开启翻译，该广播早已发出而接收器尚未注册，初始值无法被正确同步。

**Fix**：删除跨进程 prefs 读取，改为握手机制。PlayerService 注册完广播接收器后发送 `ACTION_PLAYER_READY`，主进程收到后在自己进程内可靠地读取 prefs，通过 `ACTION_SETTINGS_SNAPSHOT` 将真实值推回 PlayerService。